### PR TITLE
New LRO implementation

### DIFF
--- a/msrestazure/azure_operation.py
+++ b/msrestazure/azure_operation.py
@@ -285,7 +285,7 @@ class LongRunningOperation(object):
             self.status = "InProgress"
         elif code == 200 or \
              (code == 201 and self.method == "PUT") or \
-             (code == 204 and method in {"DELETE", "POST"}):
+             (code == 204 and self.method in {"DELETE", "POST"}):
 
             status = self._get_provisioning_state()
             self.status = status or 'Succeeded'

--- a/msrestazure/azure_operation.py
+++ b/msrestazure/azure_operation.py
@@ -32,7 +32,7 @@ try:
 except ImportError:
     from urllib.parse import urlparse
 
-from msrest.exceptions import DeserializationError
+from msrest.exceptions import DeserializationError, ClientException
 from msrestazure.azure_exceptions import CloudError
 
 
@@ -184,7 +184,7 @@ class LongRunningOperation(object):
                 response.status_code = 200
                 resource = self.get_outputs(response)
                 response.status_code = previous_status
-            except Exception:
+            except ClientException:
                 pass
         return resource
 
@@ -251,6 +251,8 @@ class LongRunningOperation(object):
             elif response.status_code == 204:
                 self.status = 'Succeeded'
                 self.resource = None
+            else:
+                raise OperationFailed("Invalid status found")
             return
         raise OperationFailed("Operation failed or cancelled")
 

--- a/msrestazure/azure_operation.py
+++ b/msrestazure/azure_operation.py
@@ -63,7 +63,7 @@ def _validate(url):
     """Validate a url.
 
     :param str url: Polling URL extracted from response header.
-    :raises: ValueError if URL has not scheme or host.
+    :raises: ValueError if URL has no scheme or host.
     """
     if url is None:
         return

--- a/msrestazure/azure_operation.py
+++ b/msrestazure/azure_operation.py
@@ -76,7 +76,7 @@ def _get_header_url(response, header_name):
 
     :param requests.Response response: REST call response.
     :param str header_name: Header name.
-    :returns: URL if valid AND exists, None otherwise
+    :returns: URL if not None AND valid, None otherwise
     """
     url = response.headers.get(header_name)
     try:

--- a/msrestazure/azure_operation.py
+++ b/msrestazure/azure_operation.py
@@ -183,10 +183,7 @@ class LongRunningOperation(object):
         if self._is_empty(response):
             return None
         body = response.json()
-        try:
-            return body.get("properties", {}).get("provisioningState")
-        except AttributeError:
-            return None
+        return body.get("properties", {}).get("provisioningState")
 
     def _process_http_status_code(self, response):
         """Process response based on specific status code.
@@ -228,7 +225,6 @@ class LongRunningOperation(object):
         :param requests.Response response: latest REST call response.
         """
         self.status = 'Succeeded'
-        self.resource = None
 
     def should_do_final_get(self, response):
         """Check whether the polling should end doing a final GET.
@@ -246,15 +242,6 @@ class LongRunningOperation(object):
         :param requests.Response response: initial REST call response.
         """
         self._raise_if_bad_http_status_and_method(response)
-
-        if self._is_empty(response):
-            self.resource = None
-        else:
-            try:
-                self.resource = self.get_outputs(response)
-            except DeserializationError:
-                self.resource = None
-
         self.set_async_url_if_present(response)
 
         if response.status_code in {200, 201, 202, 204}:

--- a/msrestazure/azure_operation.py
+++ b/msrestazure/azure_operation.py
@@ -331,7 +331,7 @@ class LongRunningOperation(object):
 
         try:
             self.resource = self.get_outputs(response)
-        except DeserializationError:
+        except Exception:
             self.resource = None
 
     def set_async_url_if_present(self, response):

--- a/msrestazure/azure_operation.py
+++ b/msrestazure/azure_operation.py
@@ -145,7 +145,7 @@ class LongRunningOperation(object):
         code = response.status_code
         if code in {200, 202} or \
            (code == 201 and self.method == 'PUT') or \
-           (code == 204 and self.method in ['DELETE', 'POST']):
+           (code == 204 and self.method in {'DELETE', 'POST'}):
             return
         raise BadStatus(
             "Invalid return status for {!r} operation".format(self.method))

--- a/msrestazure/azure_operation.py
+++ b/msrestazure/azure_operation.py
@@ -183,7 +183,10 @@ class LongRunningOperation(object):
         if self._is_empty(response):
             return None
         body = response.json()
-        return body.get("properties", {}).get("provisioningState")
+        try:
+            return body.get("properties", {}).get("provisioningState")
+        except AttributeError:
+            return None
 
     def _process_http_status_code(self, response):
         """Process response based on specific status code.
@@ -225,6 +228,7 @@ class LongRunningOperation(object):
         :param requests.Response response: latest REST call response.
         """
         self.status = 'Succeeded'
+        self.resource = None
 
     def should_do_final_get(self, response):
         """Check whether the polling should end doing a final GET.
@@ -242,6 +246,15 @@ class LongRunningOperation(object):
         :param requests.Response response: initial REST call response.
         """
         self._raise_if_bad_http_status_and_method(response)
+
+        if self._is_empty(response):
+            self.resource = None
+        else:
+            try:
+                self.resource = self.get_outputs(response)
+            except DeserializationError:
+                self.resource = None
+
         self.set_async_url_if_present(response)
 
         if response.status_code in {200, 201, 202, 204}:

--- a/test/unittest_operation.py
+++ b/test/unittest_operation.py
@@ -179,6 +179,17 @@ class TestLongRunningOperation(unittest.TestCase):
         self.assertEqual(poll.result().name, TEST_NAME)
         self.assertIsNone(poll._response.randomFieldFromPollLocationHeader)
 
+        # Test polling initial payload invalid (SQLDb)
+        response_body = {}  # Empty will raise
+        response = TestLongRunningOperation.mock_send(
+            'PUT', 201,
+            {'location': LOCATION_URL}, response_body)
+        poll = AzureOperationPoller(response,
+            TestLongRunningOperation.mock_outputs,
+            TestLongRunningOperation.mock_update, 0)
+        self.assertEqual(poll.result().name, TEST_NAME)
+        self.assertIsNone(poll._response.randomFieldFromPollLocationHeader)
+
         # Test fail to poll from azure-asyncoperation header
         response = TestLongRunningOperation.mock_send(
             'PUT', 201,

--- a/test/unittest_operation.py
+++ b/test/unittest_operation.py
@@ -138,6 +138,25 @@ class TestLongRunningOperation(unittest.TestCase):
                 TestLongRunningOperation.mock_outputs,
                 TestLongRunningOperation.mock_update, 0).result()
 
+        # Test with no polling necessary
+        response_body = {
+            'properties':{'provisioningState': 'Succeeded'},
+            'name': TEST_NAME
+        }
+        response = TestLongRunningOperation.mock_send(
+            'PUT', 201,
+            {}, response_body
+        )
+        def no_update_allowed(url, headers=None):
+            raise ValueError("Should not try to update")
+        poll = AzureOperationPoller(response,
+            TestLongRunningOperation.mock_outputs,
+            no_update_allowed,
+            0
+        )
+        self.assertEqual(poll.result().name, TEST_NAME)
+        self.assertFalse(hasattr(poll._response, 'randomFieldFromPollAsyncOpHeader'))
+
         # Test polling from azure-asyncoperation header
         response = TestLongRunningOperation.mock_send(
             'PUT', 201,

--- a/test/unittest_operation.py
+++ b/test/unittest_operation.py
@@ -79,9 +79,7 @@ class TestLongRunningOperation(unittest.TestCase):
         response = mock.create_autospec(Response)
         response.request = mock.create_autospec(Request)
         response.request.method = 'GET'
-        if not headers:
-            headers = {}
-        response.headers = headers
+        response.headers = headers or {}
         
         if url == ASYNC_URL:
             response.request.url = url

--- a/test/unittest_operation.py
+++ b/test/unittest_operation.py
@@ -272,7 +272,19 @@ class TestLongRunningOperation(unittest.TestCase):
                 TestLongRunningOperation.mock_outputs,
                 TestLongRunningOperation.mock_update, 0).result()
 
-    def test_long_running_post_delete(self):
+    def test_long_running_delete(self):
+        # Test polling from azure-asyncoperation header
+        response = TestLongRunningOperation.mock_send(
+            'DELETE', 202,
+            {'azure-asyncoperation': ASYNC_URL})
+        poll = AzureOperationPoller(response,
+            TestLongRunningOperation.mock_outputs,
+            TestLongRunningOperation.mock_update, 0)
+        poll.wait()
+        self.assertIsNone(poll.result())
+        self.assertIsNone(poll._response.randomFieldFromPollAsyncOpHeader)
+
+    def test_long_running_post(self):
 
         # Test throw on non LRO related status code
         response = TestLongRunningOperation.mock_send('POST', 201, {})

--- a/test/unittest_operation.py
+++ b/test/unittest_operation.py
@@ -138,25 +138,6 @@ class TestLongRunningOperation(unittest.TestCase):
                 TestLongRunningOperation.mock_outputs,
                 TestLongRunningOperation.mock_update, 0).result()
 
-        # Test with no polling necessary
-        response_body = {
-            'properties':{'provisioningState': 'Succeeded'},
-            'name': TEST_NAME
-        }
-        response = TestLongRunningOperation.mock_send(
-            'PUT', 201,
-            {}, response_body
-        )
-        def no_update_allowed(url, headers=None):
-            raise ValueError("Should not try to update")
-        poll = AzureOperationPoller(response,
-            TestLongRunningOperation.mock_outputs,
-            no_update_allowed,
-            0
-        )
-        self.assertEqual(poll.result().name, TEST_NAME)
-        self.assertFalse(hasattr(poll._response, 'randomFieldFromPollAsyncOpHeader'))
-
         # Test polling from azure-asyncoperation header
         response = TestLongRunningOperation.mock_send(
             'PUT', 201,


### PR DESCRIPTION
Initially, I wanted to fix the 200/PATCH/Location situation that must be detected as InProgress and not Finished as currently. Finally I went further into a refactor/learning experience. This PR to capitalize the work done these last two days and get first feedback from @annatisch and @brettcannon 

Major points on code:

- Several function renames to better fit actual content. Split following SRP pattern sometime.
- Fix for 200/PATCH/Location situation
- Algorithm rebuilt:

  - Resource is now replaced by each call. No more keeping first resource as backup (discussed with @annatisch)
  - Get status for each case Async/Location/Resource situation have been revamped based one the C# client

Unittests:

- Fix incorrect use of Headers in update mock
- Fix incomplete getoutputs mock. Now raise if model is incomplete, to better fit real situation. Related to https://github.com/Azure/msrest-for-python/pull/5
- Add 200/Patch/Location test (from DocDB)
- Add 200/Patch/Async test (inspired from DocDB)
- Add 201/PUT/Succeeded/No Headers (from DevTestLabs)

Travis might need https://github.com/Azure/msrest-for-python/pull/5 to be green, we will see, all tests green on my machine.

19 tests KO (for 46 OK) on the Azure SDK for Python tests. At first sight, it's mostly (more than half) because we need to record the tests again, since we're doing in some situation one final GET that we weren't doing before (because we were using the Resource from the initial requests). More investigation tomorrow.

