### PR TITLE
Add Azure Extensions default value in conf

### DIFF
--- a/msrestazure/azure_configuration.py
+++ b/msrestazure/azure_configuration.py
@@ -44,6 +44,8 @@ class AzureConfiguration(Configuration):
     def __init__(self, base_url, filepath=None):
         super(AzureConfiguration, self).__init__(base_url, filepath)
         self.long_running_operation_timeout = 30
+        self.accept_language = 'en-US'
+        self.generate_client_request_id = True
         self.add_user_agent("msrest_azure/{}".format(msrestazure_version))
 
     def save(self, filepath):


### PR DESCRIPTION
Needed for https://github.com/Azure/msrestazure-for-python/issues/13, since `__init__` will not contain default value anymore.

In general, any new Azure Extensions should be added in `azure_configuration` first.