### PR TITLE
Add automatic provider register hook

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,2 +1,3 @@
 -e .
 mock;python_version<="2.7"
+httpretty

--- a/msrestazure/azure_configuration.py
+++ b/msrestazure/azure_configuration.py
@@ -29,10 +29,15 @@ try:
 except ImportError:
     from ConfigParser import NoOptionError
 
-from .version import msrestazure_version
+import logging
+
 from msrest import Configuration
 from msrest.exceptions import raise_with_traceback
 
+from .version import msrestazure_version
+from .tools import register_rp_hook
+
+_LOGGER = logging.getLogger(__name__)
 
 class AzureConfiguration(Configuration):
     """Azure specific client configuration.
@@ -47,6 +52,14 @@ class AzureConfiguration(Configuration):
         self.accept_language = 'en-US'
         self.generate_client_request_id = True
         self.add_user_agent("msrest_azure/{}".format(msrestazure_version))
+
+        # Check if "hasattr", just in case msrest is older than msrestazure
+        if hasattr(self, 'hooks'):
+            self.hooks.append(register_rp_hook)
+        else:
+            _LOGGER.warning(("Your 'msrest' version is too old to activate all the ",
+                             "features of 'msrestazure'. Please update using",
+                             "'pip install -U msrest'"))
 
     def save(self, filepath):
         """Save current configuration to file.

--- a/msrestazure/azure_configuration.py
+++ b/msrestazure/azure_configuration.py
@@ -57,8 +57,8 @@ class AzureConfiguration(Configuration):
         if hasattr(self, 'hooks'):
             self.hooks.append(register_rp_hook)
         else:
-            _LOGGER.warning(("Your 'msrest' version is too old to activate all the ",
-                             "features of 'msrestazure'. Please update using",
+            _LOGGER.warning(("Your 'msrest' version is too old to activate all the "
+                             "features of 'msrestazure'. Please update using"
                              "'pip install -U msrest'"))
 
     def save(self, filepath):

--- a/msrestazure/tools.py
+++ b/msrestazure/tools.py
@@ -67,14 +67,15 @@ def _extract_subscription_url(url):
 
 def _register_rp(session, url_prefix, rp_name):
     """Synchronously register the RP is paremeter."""
-    url = "{}providers/{}/register?api-version=2016-02-01".format(url_prefix, rp_name)
+    post_url = "{}providers/{}/register?api-version=2016-02-01".format(url_prefix, rp_name)
+    get_url = "{}providers/{}?api-version=2016-02-01".format(url_prefix, rp_name)
     _LOGGER.warning("Resource provider '%s' used by the command is not "
-                    "registered. We are registering for you", rp_name)
-    session.post(url)
+                    "registered. We are registering for you.", rp_name)
+    session.post(post_url)
 
     while True:
         time.sleep(10)
-        rp_info = session.get(url).json()
+        rp_info = session.get(get_url).json()
         if rp_info['registrationState'] == 'Registered':
             _LOGGER.warning("Registration succeeded.")
             break

--- a/msrestazure/tools.py
+++ b/msrestazure/tools.py
@@ -28,6 +28,7 @@ import json
 import re
 import logging
 import time
+import uuid
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,7 +44,13 @@ def register_rp_hook(r, *args, **kwargs):
             session = kwargs['msrest']['session']
             url_prefix = _extract_subscription_url(r.request.url)
             _register_rp(session, url_prefix, rp_name)
-            return session.send(r.request)
+            time.sleep(10)
+            req = r.request
+            # Change the 'x-ms-client-request-id' otherwise the Azure endpoint
+            # just returns the same 409 payload without looking at the actual query
+            if 'x-ms-client-request-id' in req.headers:
+                req['x-ms-client-request-id'] = str(uuid.uuid1())
+            return session.send(req)
 
 def _check_rp_not_registered_err(response):
     try:

--- a/msrestazure/tools.py
+++ b/msrestazure/tools.py
@@ -44,7 +44,6 @@ def register_rp_hook(r, *args, **kwargs):
             url_prefix = _extract_subscription_url(r.request.url)
             _register_rp(session, url_prefix, rp_name)
             return session.send(r.request)
-    return r
 
 def _check_rp_not_registered_err(response):
     try:

--- a/msrestazure/tools.py
+++ b/msrestazure/tools.py
@@ -60,7 +60,7 @@ def _extract_subscription_url(url):
     """Extract the first part of the URL, just after subscription:
     https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/
     """
-    match = re.match(r".*/subscriptions/[0-9-]+/", url, re.IGNORECASE)
+    match = re.match(r".*/subscriptions/[a-f0-9-]+/", url, re.IGNORECASE)
     if not match:
         raise ValueError("Unable to extract subscription ID from URL")
     return match.group(0)

--- a/msrestazure/tools.py
+++ b/msrestazure/tools.py
@@ -1,0 +1,80 @@
+# --------------------------------------------------------------------------
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the ""Software""), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+# --------------------------------------------------------------------------
+
+import json
+import re
+import logging
+import time
+
+_LOGGER = logging.getLogger(__name__)
+
+def register_rp_hook(r, *args, **kwargs):
+    """This is a requests hook to register RP automatically.
+
+    See requests documentation for details of the signature of this function.
+    http://docs.python-requests.org/en/master/user/advanced/#event-hooks
+    """
+    if r.status_code == 409 and 'msrest' in kwargs:
+        rp_name = _check_rp_not_registered_err(r)
+        if rp_name:
+            session = kwargs['msrest']['session']
+            url_prefix = _extract_subscription_url(r.request.url)
+            _register_rp(session, url_prefix, rp_name)
+            return session.send(r.request)
+    return r
+
+def _check_rp_not_registered_err(response):
+    try:
+        response = json.loads(response.content.decode())
+        if response['error']['code'] == 'MissingSubscriptionRegistration':
+            match = re.match(r".*'(.*)'", response['error']['message'])
+            return match.group(1)
+    except Exception:  # pylint: disable=broad-except
+        pass
+    return None
+
+def _extract_subscription_url(url):
+    """Extract the first part of the URL, just after subscription:
+    https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/
+    """
+    match = re.match(r".*/subscriptions/[0-9-]+/", url, re.IGNORECASE)
+    if not match:
+        raise ValueError("Unable to extract subscription ID from URL")
+    return match.group(0)
+
+def _register_rp(session, url_prefix, rp_name):
+    """Synchronously register the RP is paremeter."""
+    url = "{}providers/{}/register?api-version=2016-02-01".format(url_prefix, rp_name)
+    _LOGGER.warning("Resource provider '%s' used by the command is not "
+                    "registered. We are registering for you", rp_name)
+    session.post(url)
+
+    while True:
+        time.sleep(10)
+        rp_info = session.get(url).json()
+        if rp_info['registrationState'] == 'Registered':
+            _LOGGER.warning("Registration succeeded.")
+            break

--- a/test/unittest_tools.py
+++ b/test/unittest_tools.py
@@ -1,0 +1,101 @@
+#--------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved. 
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the ""Software""), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+#--------------------------------------------------------------------------
+
+import unittest
+import json
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+import requests
+import httpretty
+
+from msrestazure.azure_configuration import AzureConfiguration
+
+class TestTools(unittest.TestCase):
+
+    @httpretty.activate
+    @mock.patch('time.sleep', return_value=None)
+    def test_register_rp_hook(self, time_sleep):
+        """Protocol:
+        - We call the provider and get a 409 provider error
+        - Now we POST register provider and get "Registering"
+        - Now we GET register provider and get "Registered"
+        - We call again the first endpoint and this time this succeed
+        """
+
+        provider_url = ("https://management.azure.com/"
+                        "subscriptions/00000000-0000-0000-0000-000000000000/"
+                        "resourceGroups/clitest.rg000001/"
+                        "providers/Microsoft.Sql/servers/ygserver123?api-version=2014-04-01")
+
+        provider_error = ('{"error":{"code":"MissingSubscriptionRegistration", '
+                          '"message":"The subscription registration is in \'Unregistered\' state. '
+                          'The subscription must be registered to use namespace \'Microsoft.Sql\'. '
+                          'See https://aka.ms/rps-not-found for how to register subscriptions."}}')
+
+        provider_success = '{"success": true}'
+
+        httpretty.register_uri(httpretty.PUT,
+                               provider_url,
+                               responses=[
+                                   httpretty.Response(body=provider_error, status=409),
+                                   httpretty.Response(body=provider_success),
+                               ],
+                               content_type="application/json")
+
+        register_url = ("https://management.azure.com/"
+                        "subscriptions/00000000-0000-0000-0000-000000000000/"
+                        "providers/Microsoft.Sql/register?api-version=2016-02-01")
+
+        register_post_result = {
+            "registrationState":"Registering"
+        }
+        register_get_result = {
+            "registrationState":"Registered"
+        }
+
+        httpretty.register_uri(httpretty.POST,
+                               register_url,
+                               body=json.dumps(register_post_result),
+                               content_type="application/json")
+
+        httpretty.register_uri(httpretty.GET,
+                               register_url,
+                               body=json.dumps(register_get_result),
+                               content_type="application/json")
+
+        configuration = AzureConfiguration(None)
+        register_rp_hook = configuration.hooks[0]
+
+        session = requests.Session()
+        def rp_cb(r, *args, **kwargs):
+            kwargs.setdefault("msrest", {})["session"] = session
+            return register_rp_hook(r, *args, **kwargs)
+        session.hooks['response'].append(rp_cb)
+
+        response = session.put(provider_url)
+        self.assertTrue(response.json()['success'])

--- a/test/unittest_tools.py
+++ b/test/unittest_tools.py
@@ -48,7 +48,7 @@ class TestTools(unittest.TestCase):
         """
 
         provider_url = ("https://management.azure.com/"
-                        "subscriptions/00000000-0000-0000-0000-000000000000/"
+                        "subscriptions/12345678-9abc-def0-0000-000000000000/"
                         "resourceGroups/clitest.rg000001/"
                         "providers/Microsoft.Sql/servers/ygserver123?api-version=2014-04-01")
 
@@ -68,7 +68,7 @@ class TestTools(unittest.TestCase):
                                content_type="application/json")
 
         register_url = ("https://management.azure.com/"
-                        "subscriptions/00000000-0000-0000-0000-000000000000/"
+                        "subscriptions/12345678-9abc-def0-0000-000000000000/"
                         "providers/Microsoft.Sql/register?api-version=2016-02-01")
 
         register_post_result = {

--- a/test/unittest_tools.py
+++ b/test/unittest_tools.py
@@ -67,24 +67,29 @@ class TestTools(unittest.TestCase):
                                ],
                                content_type="application/json")
 
-        register_url = ("https://management.azure.com/"
-                        "subscriptions/12345678-9abc-def0-0000-000000000000/"
-                        "providers/Microsoft.Sql/register?api-version=2016-02-01")
+        register_post_url = ("https://management.azure.com/"
+                             "subscriptions/12345678-9abc-def0-0000-000000000000/"
+                             "providers/Microsoft.Sql/register?api-version=2016-02-01")
 
         register_post_result = {
             "registrationState":"Registering"
         }
+
+        register_get_url = ("https://management.azure.com/"
+                            "subscriptions/12345678-9abc-def0-0000-000000000000/"
+                            "providers/Microsoft.Sql?api-version=2016-02-01")
+
         register_get_result = {
             "registrationState":"Registered"
         }
 
         httpretty.register_uri(httpretty.POST,
-                               register_url,
+                               register_post_url,
                                body=json.dumps(register_post_result),
                                content_type="application/json")
 
         httpretty.register_uri(httpretty.GET,
-                               register_url,
+                               register_get_url,
                                body=json.dumps(register_get_result),
                                content_type="application/json")
 


### PR DESCRIPTION
@yugangw-msft 
- This is not tested real on Azure, but HTTPretty is configured using your record.
- Tests will break if new msrest is not released, but note that this is NOT a requirement. I print a warning if msrest mismatch.