### PR TITLE
Test Server fix on exception

### DIFF
--- a/msrestazure/azure_exceptions.py
+++ b/msrestazure/azure_exceptions.py
@@ -164,6 +164,9 @@ class CloudError(ClientException):
             self.error = self.deserializer('CloudErrorRoot', response).error
         except DeserializationError:
             self.error = None
+        except AttributeError:
+            # So far seen on Autorest test server only.
+            self.error = None
         else:
             if self.error:
                 if not self.error.error or not self.error.message:


### PR DESCRIPTION
To accommodate test server that send error on Azure mode using `{message:'Bad'}` and not `{error:{message:'Bad'}`

FYI @olydis 
I improved my ARM exception parsing to follow Odata v4 a few weeks back, as expected from ARM. Syntax is then `{error:{message:{}}` (this is the Odata v4 spec).
Test server on Azure side returns some `{message:'Bad'}` (which is not ARM compliant). I don't expect the test server on the Azure side to test something that is impossible in ARM :/. Note that this mrestazure is in production for a few weeks now (if some team were returning `{message:'Bad'}`, this would have break CLI/SDK).

This requires a bugfix release of msrestazure, just to make the testserver happy, but won't hurt if some ARM teams does not respect the spec, so I'll do it.