### PR TITLE
Add 'innererror' property bag to CloudErrorData contract

### DIFF
--- a/msrestazure/azure_exceptions.py
+++ b/msrestazure/azure_exceptions.py
@@ -24,6 +24,8 @@
 #
 # --------------------------------------------------------------------------
 
+import json
+
 from requests import RequestException
 
 from msrest.exceptions import ClientException
@@ -42,6 +44,7 @@ class CloudErrorData(object):
         'message': {'key': 'message', 'type': 'str'},
         'target': {'key': 'target', 'type': 'str'},
         'details': {'key': 'details', 'type': '[CloudErrorData]'},
+        'innererror': {'key': 'innererror', 'type': 'object'},
         'data': {'key': 'values', 'type': '{str}'}
         }
 
@@ -52,6 +55,7 @@ class CloudErrorData(object):
         self.error_time = None
         self.target = kwargs.get('target')
         self.details = kwargs.get('details')
+        self.innererror = kwargs.get('innererror')
         self.data = kwargs.get('data')
         super(CloudErrorData, self).__init__(*args)
 
@@ -74,7 +78,12 @@ class CloudErrorData(object):
             for error_obj in self.details:
                 error_str += "\n\tError Code: {}".format(error_obj.error)
                 error_str += "\n\tMessage: {}".format(error_obj.message)
-                error_str += "\n\tTarget: {}".format(error_obj.target)
+                if error_obj.target:
+                    error_str += "\n\tTarget: {}".format(error_obj.target)
+                if error_obj.innererror:
+                    error_str += "\nInner error: {}".format(json.dumps(error_obj.innererror, indent=4))
+        if self.innererror:
+            error_str += "\nInner error: {}".format(json.dumps(self.innererror, indent=4))
         error_bytes = error_str.encode()
         return error_bytes.decode('ascii')
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -110,11 +110,15 @@ class TestCloudException(unittest.TestCase):
                     "target": "$search",
                     "message": "$search query option not supported",
                 }
-            ]
+            ],
+            "innererror": {
+                "customKey": "customValue"
+            }
         }
         cloud_exp = self._d(CloudErrorData(), message)
         self.assertEqual(cloud_exp.target, 'query')
         self.assertEqual(cloud_exp.details[0].target, '$search')
+        self.assertEqual(cloud_exp.innererror['customKey'], 'customValue')
 
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -119,6 +119,7 @@ class TestCloudException(unittest.TestCase):
         self.assertEqual(cloud_exp.target, 'query')
         self.assertEqual(cloud_exp.details[0].target, '$search')
         self.assertEqual(cloud_exp.innererror['customKey'], 'customValue')
+        self.assertIn('customValue', str(cloud_exp))
 
 
 


### PR DESCRIPTION
The data contract for ARM errors includes `innererror` field which is a property bag with unspecified contents as per [OData 4.0 spec](http://docs.oasis-open.org/odata/odata-json-format/v4.0/os/odata-json-format-v4.0-os.html#_Toc372793091). This field wasn't used by ARM up until now, but recently there was a change related to Azure Policy that makes heavy use of this property bag. It is already deployed in all regions and consumed by Azure Portal, so now would be a good time to support it in SDKs as well.

The new errors are generated by the ARM Frontdoor itself, so CloudErrorData seems like the most appropriate contract to include it.