### PR TITLE
Modifies session if provided

### DIFF
--- a/msrestazure/azure_active_directory.py
+++ b/msrestazure/azure_active_directory.py
@@ -260,9 +260,9 @@ class AADMixin(OAuthTokenAuthentication):
         :rtype: requests.Session.
         """
         if 'refresh_token' in self.token:
-            with self._setup_session() as session:
+            with self._setup_session() as oauth_session:
                 try:
-                    token = session.refresh_token(self.token_uri,
+                    token = oauth_session.refresh_token(self.token_uri,
                                                   refresh_token=self.token['refresh_token'],
                                                   verify=self.verify,
                                                   proxies=self.proxies,
@@ -274,7 +274,7 @@ class AADMixin(OAuthTokenAuthentication):
                 self._default_token_cache(self.token)
         else:
             self.set_token()
-        return self.signed_session(session)
+        return self.signed_session(session or oauth_session)
 
     def clear_cached_token(self):
         """Clear any stored tokens.

--- a/msrestazure/azure_active_directory.py
+++ b/msrestazure/azure_active_directory.py
@@ -274,7 +274,7 @@ class AADMixin(OAuthTokenAuthentication):
                 self._default_token_cache(self.token)
         else:
             self.set_token()
-        return self.signed_session(session or oauth_session)
+        return self.signed_session(session)
 
     def clear_cached_token(self):
         """Clear any stored tokens.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -634,7 +634,7 @@ def test_refresh_aadtokencredentials_existing_session(user_password):
 
     creds.signed_session(root_session)
 
-    response = session.get("https://management.azure.com/subscriptions?api-version=2016-06-01")
+    response = root_session.get("https://management.azure.com/subscriptions?api-version=2016-06-01")
     response.raise_for_status()  # Should never raise
 
     # Hacking the token time
@@ -643,11 +643,11 @@ def test_refresh_aadtokencredentials_existing_session(user_password):
 
     try:
         creds.signed_session(root_session)
-        response = session.get("https://management.azure.com/subscriptions?api-version=2016-06-01")
+        response = root_session.get("https://management.azure.com/subscriptions?api-version=2016-06-01")
         pytest.fail("Requests should have failed")
     except oauthlib.oauth2.rfc6749.errors.TokenExpiredError:
         creds.refresh_session(root_session)
-        response = session.get("https://management.azure.com/subscriptions?api-version=2016-06-01")
+        response = root_session.get("https://management.azure.com/subscriptions?api-version=2016-06-01")
         response.raise_for_status()  # Should never raise
 
 if __name__ == '__main__':


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-python/issues/2779

msrest's ServiceClient expects the refresh_session method to modify the session if the method is provided with one.  So now the context manager that originally overwrote the session parameter now creates a new one.  Plus the return will pass either the original session (if given) or the new OAuth2Session object that was created.