### PR TITLE
support local creds probing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ coverage.xml
 Pipfile.lock
 build
 dist
-env

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage.xml
 Pipfile.lock
 build
 dist
+env

--- a/msrestazure/azure_local_creds_prober.py
+++ b/msrestazure/azure_local_creds_prober.py
@@ -169,6 +169,7 @@ class CLICredentials(BasicTokenAuthentication):
         self.cli_path = cli_path
         self.subscription_id = subscription_id
         self.expires_on = None
+        self.resource = None
 
     def set_token(self):
         from dateutil import parser
@@ -187,12 +188,14 @@ class CLICredentials(BasicTokenAuthentication):
         args = [self.cli_path, 'account', 'get-access-token']
         if self.subscription_id:
             args.extend(['--subscription', self.subscription_id])
+        if self.resource:
+            args.extend(['--resource', self.resource])
         process = Popen(args, stdout=PIPE, stderr=PIPE)
         stdout, stderr = process.communicate()
         process.wait()
         if stderr:
             raise ValueError('Retrieving acccess token failed: ' + stderr)
-        return json.loads(stdout)
+        return json.loads(stdout.decode())
 
     def signed_session(self, session=None):
         self.set_token()
@@ -209,6 +212,7 @@ def _get_creds_through_local_probing(**kwargs):
     for prober in probers:
         creds = prober.probe()
         if creds:
+            creds.resource = resource
             return creds, prober
     raise ValueError('No credential was detected from the local machine')
 

--- a/msrestazure/azure_local_creds_prober.py
+++ b/msrestazure/azure_local_creds_prober.py
@@ -1,3 +1,30 @@
+#--------------------------------------------------------------------------
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the ""Software""), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+#--------------------------------------------------------------------------
+
+
 import os
 import json
 import platform

--- a/msrestazure/azure_local_creds_prober.py
+++ b/msrestazure/azure_local_creds_prober.py
@@ -39,7 +39,9 @@ _LOGGER = logging.getLogger(__name__)
 #pylint: disable=too-few-public-methods,missing-docstring
 
 class CredsProber:
-
+    '''
+    Prober base class
+    '''
     def __init__(self, resource):
         self.enabled = True
         self.resource = resource
@@ -64,7 +66,9 @@ class CredsProber:
 
 
 class ManagedServiceIdentityProber(CredsProber):
-
+    '''
+    Detect managed service identity coming with VM, VM scaleset, and App Service
+    '''
     def probe(self):
         if not self.enabled:
             return None
@@ -78,12 +82,12 @@ class ManagedServiceIdentityProber(CredsProber):
 
 class ConnectionStrEnvProber(CredsProber):
     '''
-    Detect environment variable AZURE_CONN_STR
+    Detect environment variable AZURE_CONNECTION_STRING
     '''
     def probe(self):
         creds = None
-        if self.enabled and os.environ.get('AZURE_CONN_STR'):
-            auth_info = json.loads(os.environ.get('AZURE_CONN_STR'))
+        if self.enabled and os.environ.get('AZURE_CONNECTION_STRING'):
+            auth_info = json.loads(os.environ.get('AZURE_CONNECTION_STRING'))
             creds = ServicePrincipalCredentials(client_id=auth_info['clientId'],
                                                 secret=auth_info['clientSecret'],
                                                 tennt_id=auth_info['tenantId'])
@@ -91,7 +95,7 @@ class ConnectionStrEnvProber(CredsProber):
         return None
 
     def probe_subscription(self, creds):
-        return json.loads(os.environ.get('AZURE_CONN_STR'))['subscriptionId']
+        return json.loads(os.environ.get('AZURE_CONNECTION_STRING'))['subscriptionId']
 
 
 class ServicePrincipalEnvProber(CredsProber):
@@ -157,7 +161,9 @@ class AzureCLIProber(CredsProber):
 
 
 class CLICredentials(BasicTokenAuthentication):
-
+    '''
+    Credentials objects for AAD token retrieved through sub-shelling "az account get-access-token"  
+    '''
     def __init__(self, cli_path, subscription_id=None):
         super(CLICredentials, self).__init__(None)
         self.cli_path = cli_path
@@ -224,6 +230,9 @@ def get_creds_through_local_probing(**kwargs):
 
 
 def get_client_through_local_creds_probing(client_class, **kwargs):
+    '''
+    Helper method to create management client using probed local credentials
+    '''
     creds, prober = _get_creds_through_local_probing(**kwargs)
     subscription_id = kwargs.get('subscription_id')
     if not subscription_id:

--- a/msrestazure/azure_local_creds_prober.py
+++ b/msrestazure/azure_local_creds_prober.py
@@ -44,41 +44,61 @@ class CredsProber:
         self.enabled = True
         self.resource = resource
 
+    def probe_subscription(self, creds):  # pylint: disable=no-self-use
+        subscription_id = None
+        try:
+            from azure.mgmt.resource.subscriptions import SubscriptionClient
+            subscriptions = list(SubscriptionClient(creds).subscriptions.list())
+            if subscriptions:
+                subscription_ids = [s.id.split('/')[-1] for s in subscriptions]
+                subscription_id = subscription_ids[0]
+                _LOGGER.warning('Found subscription "%s" to use', subscription_ids[0])
+                if len(subscription_ids) > 1:
+                    _LOGGER.warning('You also have accesses to a few other subscriptions "%S".'
+                                    ' You can supply subscription_id on invoking probers')
+        except ImportError:  # should be rare
+            _LOGGER.warning('Failed to load azure.mgmt.resource.subscriptions to find the default'
+                            ' subscription. If this is expected, supply subscription_id on creating'
+                            ' the probe object')
+        return subscription_id
+
 
 class ManagedServiceIdentityProber(CredsProber):
 
-    def probe(self, subscription_id=None):
+    def probe(self):
         if not self.enabled:
             return None
         try:
             creds = MSIAuthentication()
             _LOGGER.warning('Managed system identity was detected')
-            return creds, subscription_id or _get_subscription_id(creds)
+            return creds
         except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError):
-            return None, None
+            return None
 
 
 class ConnectionStrEnvProber(CredsProber):
     '''
     Detect environment variable AZURE_CONN_STR
     '''
-    def probe(self, subscription_id=None):
+    def probe(self):
         creds = None
         if self.enabled and os.environ.get('AZURE_CONN_STR'):
             auth_info = json.loads(os.environ.get('AZURE_CONN_STR'))
             creds = ServicePrincipalCredentials(client_id=auth_info['clientId'],
                                                 secret=auth_info['clientSecret'],
                                                 tennt_id=auth_info['tenantId'])
-            return creds, (subscription_id or auth_info.get('subscriptionId') or
-                           _get_subscription_id(creds))
-        return None, None
+            return creds
+        return None
+
+    def probe_subscription(self, creds):
+        return json.loads(os.environ.get('AZURE_CONN_STR'))['subscriptionId']
 
 
 class ServicePrincipalEnvProber(CredsProber):
     '''
     Detect envrionment variable AZURE_CLIENT_ID, AZURE_CLIENT_SECRET and AZURE_TENANT_ID
     '''
-    def probe(self, subscription_id=None):
+    def probe(self):
         creds = None
         if os.environ.get('AZURE_CLIENT_ID'):
             client_id, client_secret, tenant_id = (os.environ.get('AZURE_CLIENT_ID'),
@@ -91,16 +111,19 @@ class ServicePrincipalEnvProber(CredsProber):
                                                 tenant=tenant_id, resource=self.resource)
 
             _LOGGER.warning('Service principal credentials was detected')
-            return creds, (subscription_id or os.environ.get('AZURE_SUBSCRIPTION_ID') or
-                           _get_subscription_id(creds))
-        return None, None
+            return creds
+        return None
+
+    def probe_subscription(self, creds):
+        return (os.environ.get('AZURE_SUBSCRIPTION_ID') or
+                super(ServicePrincipalEnvProber, self).probe_subscription(creds))
 
 
 class AzureCLIProber(CredsProber):
     '''
     Detect CLI installations
     '''
-    def probe(self, subscription_id=None):  # pylint: disable=no-self-use
+    def probe(self):  # pylint: disable=no-self-use
         uname = platform.uname()
         platform_name = getattr(uname, 'system', None) or uname[0]
         platform_name = platform_name.lower()
@@ -126,13 +149,11 @@ class AzureCLIProber(CredsProber):
                         _LOGGER.warning('More than one Azure CLI are installed at "%s"'
                                         ' Pick the 1st one.', ', '.join(installed_clis))
 
-        if cli_path:
-            creds = CLICredentials(cli_path)
-            if subscription_id is None:
-                creds.set_token()
-                subscription_id = creds.subscription_id
-            return creds, subscription_id
-        return None, None
+        return CLICredentials(cli_path) if cli_path else None
+
+    def probe_subscription(self, creds):
+        creds.set_token()
+        return creds.subscription_id
 
 
 class CLICredentials(BasicTokenAuthentication):
@@ -171,26 +192,22 @@ class CLICredentials(BasicTokenAuthentication):
         self.set_token()
         return super(CLICredentials, self).signed_session(session)
 
-def _get_subscription_id(creds):
-    subscription_id = None
-    try:
-        from azure.mgmt.resource.subscriptions import SubscriptionClient
-        subscriptions = list(SubscriptionClient(creds).subscriptions.list())
-        if subscriptions:
-            subscription_ids = [s.id.split('/')[-1] for s in subscriptions]
-            subscription_id = subscription_ids[0]
-            _LOGGER.warning('Found subscription "%s" to use', subscription_ids[0])
-            if len(subscription_ids) > 1:
-                _LOGGER.warning('You also have accesses to a few other subscriptions "%S".'
-                                ' You can supply subscription_id on creating the probe object')
-    except ImportError:  # should be rare
-        _LOGGER.warning('Failed to load azure.mgmt.resource.subscriptions to find the default'
-                        ' subscription. If this is expected, supply subscription_id on creating'
-                        ' the probe object')
-    return subscription_id
+
+def _get_creds_through_local_probing(**kwargs):
+    resource = kwargs.get('resource')
+    if not resource:
+        from .azure_cloud import AZURE_PUBLIC_CLOUD
+        resource = AZURE_PUBLIC_CLOUD.endpoints.resource_manager
+    probers = [ConnectionStrEnvProber(resource), ServicePrincipalEnvProber(resource),
+               ManagedServiceIdentityProber(resource), AzureCLIProber(resource)]
+    for prober in probers:
+        creds = prober.probe()
+        if creds:
+            return creds, prober
+    raise ValueError('No credential was detected from the local machine')
 
 
-def get_client_through_local_creds_probing(client_class, **kwargs):
+def get_creds_through_local_probing(**kwargs):
     '''
     Probing logics:
     1. AZURE_CONN_STR, with SDK auth code file content in json.
@@ -202,14 +219,13 @@ def get_client_through_local_creds_probing(client_class, **kwargs):
         b. virtual machine
     4. Azure CLI, through "az account get-access-token"
     '''
-    resource = kwargs.get('resource')
-    if not resource:
-        from .azure_cloud import AZURE_PUBLIC_CLOUD
-        resource = AZURE_PUBLIC_CLOUD.endpoints.resource_manager
-    probers = [ConnectionStrEnvProber(resource), ServicePrincipalEnvProber(resource),
-               ManagedServiceIdentityProber(resource), AzureCLIProber(resource)]
-    for prober in probers:
-        creds, subscription_id = prober.probe(subscription_id=kwargs.get('subscription_id'))
-        if creds:
-            return client_class(creds, subscription_id)
-    raise ValueError('No credential was detected from the local machine')
+    creds, _ = _get_creds_through_local_probing(**kwargs)
+    return creds
+
+
+def get_client_through_local_creds_probing(client_class, **kwargs):
+    creds, prober = _get_creds_through_local_probing(**kwargs)
+    subscription_id = kwargs.get('subscription_id')
+    if not subscription_id:
+        subscription_id = prober.probe_subscription(creds)
+    return client_class(creds, subscription_id, **kwargs)

--- a/msrestazure/azure_local_creds_prober.py
+++ b/msrestazure/azure_local_creds_prober.py
@@ -84,6 +84,7 @@ class AzureLocalCredentialProber(object):
                 subscriptions = list(SubscriptionClient(creds).subscriptions.list())
                 if subscriptions:
                     subscription_ids = [s.id.split('/')[-1] for s in subscriptions]
+                    subscription_id = subscription_ids[0]
                     _LOGGER.warning('Found subscription "%s" to use', subscription_ids[0])
                     if len(subscription_ids) > 1:
                         _LOGGER.warning('You also have accesses to a few other subscriptions "%S".'

--- a/msrestazure/azure_local_creds_prober.py
+++ b/msrestazure/azure_local_creds_prober.py
@@ -1,0 +1,94 @@
+import os
+import json
+import platform
+import logging
+from subprocess import PIPE, Popen
+import requests
+from msrest.authentication import BasicTokenAuthentication
+from msrestazure.azure_active_directory import MSIAuthentication, ServicePrincipalCredentials
+
+_LOGGER = logging.getLogger(__name__)
+
+class CLICredentials(BasicTokenAuthentication):
+
+    def __init__(self, resource=None, subscription_id=None):   # allow subscriptions
+        super(CLICredentials, self).__init__(None)
+        uname = platform.uname()
+        # python 2, `platform.uname()` returns: tuple(system, node, release, version, machine, processor)
+        platform_name = getattr(uname, 'system', None) or uname[0]
+        platform_name = platform_name.lower()
+        if platform_name == 'windows':
+            program_files_folder = os.environ.get('ProgramFiles(x86)') or os.environ.get('ProgramFiles')
+            probing_paths = [os.path.join(program_files_folder, 'Microsoft SDKs', 'Azure', 'CLI2', 'wbin', 'az.cmd')]
+        else:
+            probing_paths = ['/usr/bin/az', '/usr/local/bin/az']
+        
+        cli_path = next((p for p in probing_paths if os.path.isfile(p)), None)
+        if cli_path is None:
+            raise NotImplementedError('Azure CLI is not installed')
+        self.cli_path = cli_path
+        self.resource = resource
+        self.subscription_id = subscription_id
+        self.token = None
+
+    def set_token(self):
+        args = [self.cli_path, 'account', 'get-access-token']
+        if self.subscription_id:
+            args.extend(['--subscription', self.subscription_id])
+        p = Popen(args, stdout=PIPE, stderr=PIPE)
+        stdout, stderr = p.communicate()
+        p.wait()
+        if stderr:
+            raise ValueError('Retrieving acccess token failed: ' + stderr)
+        info = json.loads(stdout)
+        self.scheme, self.token = info['tokenType'], {'access_token': info['accessToken']}
+
+    def signed_session(self, session=None):
+        # Token cache is handled by the VM extension, call each time to avoid expiration
+        self.set_token()
+        return super(CLICredentials, self).signed_session(session)
+
+
+class AzureLocalCredentialProber(object):
+
+    def __init__(self, subscription_id=None):
+        self.subscription_id = subscription_id
+        self.creds = None
+        self._probe()
+
+    def signed_session(self, session=None):
+        self.creds.signed_session(session)
+
+    def _probe(self):
+        subscription_id = self.subscription_id or os.environ.get('AZURE_SUBSCRIPTION_ID')
+        try:
+            creds = MSIAuthentication()
+            _LOGGER.warning('Managed system identity was detected')
+        except requests.exceptions.ConnectionError:
+            client_id = os.environ.get('AZURE_CLIENT_ID')
+            if client_id:
+                creds = ServicePrincipalCredentials(client_id=client_id,
+                                                    secret=os.environ.get('AZURE_CLIENT_SECRET'),
+                                                    tennt_id=os.environ.get('AZURE_TENANT_ID'))
+                _LOGGER.warning('Service principal credentials was detected')
+            else:
+                try:
+                    creds = CLICredentials()
+                    _LOGGER.warning('Azure CLI credentials was detected')
+                except NotImplementedError:
+                    raise ValueError('No credential was detected from the local machine')
+        self.creds = creds
+        if not subscription_id:
+            try:
+                from azure.mgmt.resource.subscriptions import SubscriptionClient
+                subscriptions = list(SubscriptionClient(creds).subscriptions.list())
+                if subscriptions:
+                    subscription_ids = [s.id.split('/')[-1] for s in subscriptions]
+                    _LOGGER.warning('Found subscription "%s" to use', subscription_ids[0])
+                    if len(subscription_ids) > 1:
+                        _LOGGER.warning('You also have accesses to a few other subscriptions "%S".'
+                                        ' You can supply subscription_id on creating the probe object')
+            except ImportError:  # should be rare
+                _LOGGER.warning('Failed to load azure.mgmt.resource.subscriptions to find the default subscription.'
+                                ' If this is expected, supply subscription_id on creating the probe object')
+        self.subscription_id = subscription_id

--- a/msrestazure/azure_local_creds_prober.py
+++ b/msrestazure/azure_local_creds_prober.py
@@ -40,6 +40,8 @@ class AzureLocalCredentialProber(object):
     '''
     Probing logics:
     1. Managed service identity
+        a. app service
+        b. virtual machine
     2. AZURE_CONN_STR, with SDK auth code file content in json. 
         https://github.com/Azure/azure-sdk-for-java/wiki/Authentication
     3. Individual environment variables to estabslish a service principal's creds

--- a/msrestazure/azure_local_creds_prober.py
+++ b/msrestazure/azure_local_creds_prober.py
@@ -85,6 +85,13 @@ class ManagedServiceIdentityProber(CredsProber):
         if not self.enabled:
             return None
         try:
+            # quick check  a VM with identity to avoid the long timeout in MSIAuthentication 
+            _ = requests.get('http://169.254.169.254/metadata/identity/oauth2/token',
+                                  params={'api-version': '2018-02-01',
+                                          'resource':'https://management.core.windows.net/'},
+                                  headers={'Metadata': 'true'},
+                                  timeout=1)
+
             creds = MSIAuthentication()
              # MSI is not yet supported in sovereigns
             setattr(creds, 'cloud_environment', AZURE_PUBLIC_CLOUD)

--- a/tests/test_local_creds_prober.py
+++ b/tests/test_local_creds_prober.py
@@ -1,3 +1,30 @@
+#--------------------------------------------------------------------------
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the ""Software""), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+#--------------------------------------------------------------------------
+
+
 from azure.mgmt.storage import StorageManagementClient
 from msrestazure.azure_local_creds_prober import AzureLocalCredentialProber
 

--- a/tests/test_local_creds_prober.py
+++ b/tests/test_local_creds_prober.py
@@ -25,22 +25,20 @@
 #--------------------------------------------------------------------------
 
 
-class TestCredsLocalProbing(unittest.TestCase):
+from azure.mgmt.storage import StorageManagementClient
+from azure.multiapi.storage.v2018_03_28.blob.blockblobservice import BlockBlobService
+from msrestazure.azure_local_creds_prober import (get_client_through_local_creds_probing,
+                                                  get_creds_through_local_probing)
 
-    @unittest.skip("demo sample client code")
-    def test_create_client_from_probed_creds(self):
+# test management plane
+client = get_client_through_local_creds_probing(StorageManagementClient)
+accounts = list(client.storage_accounts.list())
+print('Found {} accounts'.format(len(accounts)))
 
-        from azure.mgmt.storage import StorageManagementClient
-        from azure.multiapi.storage.v2018_03_28.blob.blockblobservice import BlockBlobService
-        from msrestazure.azure_local_creds_prober import (get_client_through_local_creds_probing,
-                                                          get_creds_through_local_probing)
+# test storage data plane
+creds = get_creds_through_local_probing(resource="https://storage.azure.com/")
+test_storage_account, container, blob, file_to_upload = 'teststor12345678', 'temp', 'hey.exe', r'c:\temp\hey.exe'
+storage_data_client = BlockBlobService(token_credential=creds, account_name=test_storage_account)
+storage_data_client.create_blob_from_path(container, blob, file_to_upload)
+print('uploaded')
 
-        # look for storage account
-        client = get_client_through_local_creds_probing(StorageManagementClient)
-        accounts = list(client.storage_accounts.list())
-        print('Found {} accounts'.format(len(accounts)))
-
-        # look for containers in the 1st storage account through storage preview service
-        creds = get_creds_through_local_probing(resource="https://storage.azure.com/")
-        storage_data_client2 = BlockBlobService(token_credential=creds, account_name=accounts[0].name)
-        print(len(list(storage_data_client2.list_containers())))

--- a/tests/test_local_creds_prober.py
+++ b/tests/test_local_creds_prober.py
@@ -26,8 +26,22 @@
 
 
 from azure.mgmt.storage import StorageManagementClient
-from msrestazure.azure_local_creds_prober import get_client_through_local_creds_probing
+from azure.multiapi.storage.v2018_03_28.blob.blockblobservice import BlockBlobService
+from msrestazure.azure_local_creds_prober import (get_client_through_local_creds_probing,
+                                                  get_creds_through_local_probing)
 
+# look for storage account
 client = get_client_through_local_creds_probing(StorageManagementClient)
 accounts = list(client.storage_accounts.list())
 print('Found {} accounts'.format(len(accounts)))
+
+# look for containers in the 1st storage account through storage preview service
+creds = get_creds_through_local_probing(resource="https://storage.azure.com/")
+storage_data_client2 = BlockBlobService(token_credential=creds, account_name=accounts[0].name)
+print(len(list(storage_data_client2.list_containers())))
+pass
+
+
+
+
+

--- a/tests/test_local_creds_prober.py
+++ b/tests/test_local_creds_prober.py
@@ -26,9 +26,8 @@
 
 
 from azure.mgmt.storage import StorageManagementClient
-from msrestazure.azure_local_creds_prober import AzureLocalCredentialProber
+from msrestazure.azure_local_creds_prober import get_client_through_local_creds_probing
 
-prober = AzureLocalCredentialProber()
-client = StorageManagementClient(prober, prober.subscription_id)
+client = get_client_through_local_creds_probing(StorageManagementClient)
 accounts = list(client.storage_accounts.list())
 print('Found {} accounts'.format(len(accounts)))

--- a/tests/test_local_creds_prober.py
+++ b/tests/test_local_creds_prober.py
@@ -4,4 +4,4 @@ from msrestazure.azure_local_creds_prober import AzureLocalCredentialProber
 prober = AzureLocalCredentialProber()
 client = StorageManagementClient(prober, prober.subscription_id)
 accounts = list(client.storage_accounts.list())
-pass
+print('Found {} accounts'.format(len(accounts)))

--- a/tests/test_local_creds_prober.py
+++ b/tests/test_local_creds_prober.py
@@ -1,0 +1,7 @@
+from azure.mgmt.storage import StorageManagementClient
+from msrestazure.azure_local_creds_prober import AzureLocalCredentialProber
+
+prober = AzureLocalCredentialProber()
+client = StorageManagementClient(prober, prober.subscription_id)
+accounts = list(client.storage_accounts.list())
+pass

--- a/tests/test_local_creds_prober.py
+++ b/tests/test_local_creds_prober.py
@@ -25,23 +25,22 @@
 #--------------------------------------------------------------------------
 
 
-from azure.mgmt.storage import StorageManagementClient
-from azure.multiapi.storage.v2018_03_28.blob.blockblobservice import BlockBlobService
-from msrestazure.azure_local_creds_prober import (get_client_through_local_creds_probing,
-                                                  get_creds_through_local_probing)
+class TestCredsLocalProbing(unittest.TestCase):
 
-# look for storage account
-client = get_client_through_local_creds_probing(StorageManagementClient)
-accounts = list(client.storage_accounts.list())
-print('Found {} accounts'.format(len(accounts)))
+    @unittest.skip("demo sample client code")
+    def test_create_client_from_probed_creds(self):
 
-# look for containers in the 1st storage account through storage preview service
-creds = get_creds_through_local_probing(resource="https://storage.azure.com/")
-storage_data_client2 = BlockBlobService(token_credential=creds, account_name=accounts[0].name)
-print(len(list(storage_data_client2.list_containers())))
-pass
+        from azure.mgmt.storage import StorageManagementClient
+        from azure.multiapi.storage.v2018_03_28.blob.blockblobservice import BlockBlobService
+        from msrestazure.azure_local_creds_prober import (get_client_through_local_creds_probing,
+                                                          get_creds_through_local_probing)
 
+        # look for storage account
+        client = get_client_through_local_creds_probing(StorageManagementClient)
+        accounts = list(client.storage_accounts.list())
+        print('Found {} accounts'.format(len(accounts)))
 
-
-
-
+        # look for containers in the 1st storage account through storage preview service
+        creds = get_creds_through_local_probing(resource="https://storage.azure.com/")
+        storage_data_client2 = BlockBlobService(token_credential=creds, account_name=accounts[0].name)
+        print(len(list(storage_data_client2.list_containers())))


### PR DESCRIPTION
For #118. 
The probe sequence:
1. Manager service identity
   only "system assigned identity" is probed, as user assigned identity would require extra arguments, and under that context users are better off using strong type credentials 
2. Environment variable `AZURE_CONNECTION_STRING` with sdk auth file content in json, which is proposed in the design review meeting in June.
    e.g. `{AZURE_CLIENT_ID='...', AZURE_CLIENT_SECRET='...', AZURE_TENANT_ID='...', AZURE_CLOUD_NAME='...'}`
    `AZURE_CLOUD_NAME` is optional. We default to public cloud
3. Individual environment variables for a service principal
    Like 2, rather using individual environment variables
4. Azure Authentication File (originating from java sdk)
5. Azure CLI credentials

Subscription id will be optional as the chainer will find them
Per suggestion, the example code includes both management plane and data plane client codes


 