### PR TITLE
Adding `is_valid_resource_name` helper.

### DIFF
--- a/msrestazure/tools.py
+++ b/msrestazure/tools.py
@@ -38,6 +38,8 @@ _ARMID_RE = re.compile(
 _CHILDREN_RE = re.compile('(?i)(/providers/(?P<child_namespace>[^/]*))?/'
                           '(?P<child_type>[^/]*)/(?P<child_name>[^/]*)')
 
+_ARMNAME_RE = re.compile('^[^<>%&:\\?/]{1,260}$')
+
 def register_rp_hook(r, *args, **kwargs):
     """This is a requests hook to register RP automatically.
 
@@ -243,3 +245,23 @@ def is_valid_resource_id(rid, exception_type=None):
     if not is_valid and exception_type:
         raise exception_type()
     return is_valid
+
+
+def is_valid_resource_name(rname, exception_type=None):
+    """Validates the given resource name to ARM guidelines, individual services may be more restrictive.
+
+    :param rname: The resource name being validated.
+    :type rname: str
+    :param exception_type: Raises this Exception if invalid.
+    :type exception_type: :class:`Exception`
+    :returns: A boolean describing whether the name is valid.
+    :rtype: bool
+    """
+
+    match = _ARMNAME_RE.match(rname)
+
+    if match:
+        return True
+    if exception_type:
+        raise exception_type()
+    return False

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -485,7 +485,7 @@ class TestTools(unittest.TestCase):
         ]
 
         for test in invalid_names:
-            self.assertFalse(is_valid_resource_name(test), '"{}" should be invalid'.format(test))
+            self.assertFalse(is_valid_resource_name(test))
 
         valid_names = [
             'abc-123',
@@ -494,7 +494,7 @@ class TestTools(unittest.TestCase):
         ]
 
         for test in valid_names:
-            self.assertTrue(is_valid_resource_name(test), '"{}" should be valid'.format(test))
+            self.assertTrue(is_valid_resource_name(test))
 
 
 if __name__ == "__main__":

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -481,7 +481,7 @@ class TestTools(unittest.TestCase):
             'knights/ni',
             'spam&eggs',
             'i<3you',
-            ''.join('a' for _ in range(261))
+            'a' * 261,
         ]
 
         for test in invalid_names:
@@ -490,7 +490,7 @@ class TestTools(unittest.TestCase):
         valid_names = [
             'abc-123',
             ' ',  # no one said it had to be a good resource name.
-            ''.join('a' for _ in range(260))
+            'a' * 260,
         ]
 
         for test in valid_names:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -34,7 +34,7 @@ import requests
 import httpretty
 
 from msrestazure.azure_configuration import AzureConfiguration
-from msrestazure.tools import parse_resource_id, is_valid_resource_id, resource_id
+from msrestazure.tools import parse_resource_id, is_valid_resource_id, resource_id, is_valid_resource_name
 
 class TestTools(unittest.TestCase):
 
@@ -474,6 +474,27 @@ class TestTools(unittest.TestCase):
         for test in tests:
             rsrc_id = resource_id(**test['id_args'])
             self.assertEqual(rsrc_id.lower(), test['resource_id'].lower())
+
+    def test_is_resource_name(self):
+        invalid_names = [
+            '',
+            'knights/ni',
+            'this&that',
+            'i<3you',
+            ''.join('a' for _ in range(261))
+        ]
+
+        for test in invalid_names:
+            self.assertFalse(is_valid_resource_name(test), '"{}" should be invalid'.format(test))
+
+        valid_names = [
+            'abc-123',
+            ' ',  # no one said it had to be a good resource name.
+            ''.join('a' for _ in range(260))
+        ]
+
+        for test in valid_names:
+            self.assertTrue(is_valid_resource_name(test), '"{}" should be valid'.format(test))
 
 
 if __name__ == "__main__":

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -479,13 +479,13 @@ class TestTools(unittest.TestCase):
         invalid_names = [
             '',
             'knights/ni',
-            'this&that',
+            'spam&eggs',
             'i<3you',
             ''.join('a' for _ in range(261))
         ]
 
         for test in invalid_names:
-            self.assertFalse(is_valid_resource_name(test))
+            assert not is_valid_resource_name(test)
 
         valid_names = [
             'abc-123',
@@ -494,7 +494,7 @@ class TestTools(unittest.TestCase):
         ]
 
         for test in valid_names:
-            self.assertTrue(is_valid_resource_name(test))
+            assert is_valid_resource_name(test)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Definition of ARM Resource name found here: https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/resource-api-reference.md#arguments-for-crud-on-resource

related to Azure/azure-cli#6343