### PR TITLE
Issue #140: Some errors contain non-ascii. Decode errors as utf8.

### DIFF
--- a/msrestazure/azure_exceptions.py
+++ b/msrestazure/azure_exceptions.py
@@ -117,7 +117,7 @@ class CloudErrorData(object):
             for error_info in self.additionalInfo:
                 error_str += "\n\t{}".format(str(error_info).replace("\n", "\n\t"))
         error_bytes = error_str.encode()
-        return error_bytes.decode('ascii')
+        return error_bytes.decode('utf8')
 
     @classmethod
     def _get_subtype_map(cls):


### PR DESCRIPTION
For example, the error for going over quota during `az vm create` contains the
word "Detail" with smart single quotes.

The proper solution is to eschew non-ascii but convincing MS (or Apple) to give
up on smart quotes is probably not an option.

https://github.com/Azure/azure-cli/pull/12200#discussion_r381434412

Signed-off-by: Nye T. Liu <nye@blockdaemon.com>