### PR TITLE
Fix leftover unicode exception python2

### DIFF
--- a/msrestazure/azure_exceptions.py
+++ b/msrestazure/azure_exceptions.py
@@ -223,7 +223,7 @@ class CloudError(ClientException):
         if not state:
             resource_content = content.get('properties', content)
             state = resource_content.get("provisioningState")
-        return "Resource state {}".format(state) if state else "none"
+        return u"Resource state {}".format(state) if state else "none"
 
     def _build_error_message(self, response):
         # Assume ClientResponse has "body", and otherwise it's a requests.Response
@@ -244,14 +244,14 @@ class CloudError(ClientException):
                 self.error = err
             if not self.message:
                 if message == "none":
-                    message = str(err)
-                msg = "Operation failed with status: {!r}. Details: {}"
+                    message = _unicode_or_str(err.message if hasattr(err, "message") else err)
+                msg = u"Operation failed with status: {!r}. Details: {}"
                 self.message = msg.format(response.reason, message)
         else:
             if not self.error:
                 self.error = response
             if not self.message:
-                msg = "Operation failed with status: {!r}. Details: {}"
+                msg = u"Operation failed with status: {!r}. Details: {}"
                 self.message = msg.format(
                     response.status_code, message)
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -180,11 +180,11 @@ class TestCloudException(unittest.TestCase):
     def test_cloud_error(self):
 
         response = Response()
-        response._content = br'{"real": true}'  # Has to be valid bytes JSON
+        response._content = br'{"real": true, "status": "BadRequ\u0454st"}'  # Has to be valid bytes JSON
         response._content_consumed = True
-        response.status_code = 400
+        response.status_code = 200
         response.headers = {"content-type": "application/json; charset=utf8"}
-        response.reason = 'BadRequest'
+        response.reason = u'BadRequ\u0454st'
 
         message = { 'error': {
             'code': '500',
@@ -192,6 +192,13 @@ class TestCloudException(unittest.TestCase):
             'values': {'invalid_attribute':'data'}
             }}
 
+        CloudError(response)
+
+        response.status_code = 400
+        response._content = br'{"real": true}'
+        CloudError(response)
+
+        response.reason = 'BadRequest'
         response._content = json.dumps(message).encode("utf-8")
 
         error = CloudError(response)


### PR DESCRIPTION
Following #151 there still some case where a mix between str and unicode exists

I ran into the issue when using the lib even with the fix. The error was related to a quota exceeded.
The server was based on "France central" so that may explain things.

To fix it locally, I just had to change [that line](https://github.com/Azure/msrestazure-for-python/blob/3583a18de2be555f7f188f6408c2097f7bfade9b/msrestazure/azure_exceptions.py#L248) but to handle all the cases, that give that.

Tested locally on python 3.6.8 and python 2.7.16.

Do not hesitate to change the code or tell me if it does not follows your style

The message received from the server is something like:

> Provisioning of resource(s) for container service _xxx_ in resource group _yyy_ failed. Message: Operation could not be completed as it results in exceeding approved standardBSFamily Cores quota. Additional details - Deployment Model: Resource Manager, Location: FranceCentral, Current Limit: 10, Current Usage: 0, Additional Required: 100, (Minimum) New Limit Required: 100. Submit a request for Quota increase at _https://aka.ms/ProdportalCRP/?#create/Microsoft.Support/Parameters/.._. by specifying parameters listed in the ‘Details’ section for deployment to succeed. Please read more about quota limits at https://docs.microsoft.com/en-us/azure/azure-supportability/per-vm-quota-requests.. Details:

The stack trace I got:

>   File "...lib/python2.7/site-packages/azure/mgmt/containerservice/v2020_04_01/operations/_managed_clusters_operations.py", line 670, in create_or_update
>     **operation_config
>   File "...lib/python2.7/site-packages/azure/mgmt/containerservice/v2020_04_01/operations/_managed_clusters_operations.py", line 619, in _create_or_update_initial
>     exp = CloudError(response)
>   File ".../lib/python2.7/site-packages/msrestazure/azure_exceptions.py", line 184, in __init__
>     self._build_error_message(response)
>   File ".../lib/python2.7/site-packages/msrestazure/azure_exceptions.py", line 242, in _build_error_message
>     self.message = msg.format(response.reason, message)
> UnicodeEncodeError: 'ascii' codec can't encode character u'\u2018' in position 725: ordinal not in range(128)