### PR TITLE
Add trailing slash to `AZURE_*_CLOUD` URLs

### DIFF
--- a/msrestazure/azure_cloud.py
+++ b/msrestazure/azure_cloud.py
@@ -153,7 +153,7 @@ AZURE_CHINA_CLOUD = Cloud(
     'AzureChinaCloud',
     endpoints=CloudEndpoints(
         management='https://management.core.chinacloudapi.cn/',
-        resource_manager='https://management.chinacloudapi.cn',
+        resource_manager='https://management.chinacloudapi.cn/',
         sql_management='https://management.core.chinacloudapi.cn:8443/',
         batch_resource_id='https://batch.chinacloudapi.cn/',
         gallery='https://gallery.chinacloudapi.cn/',
@@ -187,7 +187,7 @@ AZURE_GERMAN_CLOUD = Cloud(
     'AzureGermanCloud',
     endpoints=CloudEndpoints(
         management='https://management.core.cloudapi.de/',
-        resource_manager='https://management.microsoftazure.de',
+        resource_manager='https://management.microsoftazure.de/',
         sql_management='https://management.core.cloudapi.de:8443/',
         batch_resource_id='https://batch.cloudapi.de/',
         gallery='https://gallery.cloudapi.de/',


### PR DESCRIPTION
This commit makes the `AZURE_CHINA_CLOUD.endpoints.resource_manager` and `AZURE_GERMAN_CLOUD.endpoints.resource_manager` URLs end with a trailing slash, for consistency with the `AZURE_PUBLIC_CLOUD` and `AZURE_US_GOV_CLOUD` URLs.