### PR TITLE
Revert "Change log level"

### DIFF
--- a/msrestazure/azure_active_directory.py
+++ b/msrestazure/azure_active_directory.py
@@ -641,7 +641,7 @@ class _ImdsTokenProvider(object):
             expires_on_datetime = datetime.datetime.fromtimestamp(expires_on)
             expiration_margin = 5  # in minutes
             if datetime.datetime.now() + datetime.timedelta(minutes=expiration_margin) <= expires_on_datetime:
-                _LOGGER.debug("MSI: token is found in cache.")
+                _LOGGER.info("MSI: token is found in cache.")
                 return token_entry
             _LOGGER.info("MSI: cache is found but expired within %s minutes, so getting a new one.", expiration_margin)
             self.cache.pop(resource)


### PR DESCRIPTION
Reverts Azure/msrestazure-for-python#160

We don't want to release this change, reverting back "master" to the code as of 0.6.4